### PR TITLE
Update install instructions to work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ A Cargo subcommand to run [Roogle](https://github.com/hkmatsumoto/roogle) on loc
 
 # Installation
 ```sh
-$ cargo install roogle
+$ cargo install roogle --locked
 $ cargo install cargo-roogle
 ```


### PR DESCRIPTION
Looks like rocket needs to be pinned or something. Currently `cargo install roogle` won't work.

```
error[E0412]: cannot find type `Json` in module `content`
  --> /home/a/.cargo/registry/src/index.crates.io-6f17d22bba15001f/roogle-1.0.0/src/main.rs:24:22
   |
24 | ) -> Result<content::Json<String>, rocket::response::Debug<anyhow::Error>> {
   |                      ^^^^ not found in `content`
   |
help: consider importing this struct
   |
4  + use tracing_subscriber::fmt::format::Json;
   |
help: if you import `Json`, refer to it directly
   |
24 - ) -> Result<content::Json<String>, rocket::response::Debug<anyhow::Error>> {
24 + ) -> Result<Json<String>, rocket::response::Debug<anyhow::Error>> {
   |

...
```